### PR TITLE
chore: prepare express server and render deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: node server.cjs
+

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-  "dev": "vite",
-  "build": "vite build && node server.cjs",
-  "preview": "vite preview",
-  "start": "node server.cjs"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "start": "node server.cjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: parcelscraper
+    env: node
+    plan: free
+    autoDeploy: true
+    buildCommand: npm ci && npm run build
+    startCommand: node server.cjs
+    envVars:
+      - key: NODE_VERSION
+        value: 20.19.1
+

--- a/server.cjs
+++ b/server.cjs
@@ -1,41 +1,66 @@
 const express = require('express');
 const path = require('path');
+const cors = require('cors');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// In-memory store for the most recent payload
-let latestPropertyData = null;
+// In-memory store for webhook payload
+let latestPayload = {};
 
-// JSON + CORS
-app.use(express.json());
-app.use((req, res, next) => {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  if (req.method === 'OPTIONS') return res.sendStatus(200);
-  next();
+// Middleware
+app.use(cors());
+app.options('*', cors());
+app.use(express.json({ limit: '1mb' }));
+
+// Health check
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
 });
 
-// API: POST to receive data from Lindy; GET to let the SPA poll
+// Webhook endpoints
 app.post('/api/webhook-response', (req, res) => {
   try {
-    console.log('Received property data keys:', Object.keys(req.body || {}));
-    latestPropertyData = req.body || {};
+    if (!req.is('application/json')) {
+      return res.status(415).json({ error: 'Content-Type must be application/json' });
+    }
+    latestPayload = req.body || {};
+    console.log('Stored webhook payload');
     return res.json({ ok: true });
-  } catch (e) {
-    console.error('Webhook error:', e);
+  } catch (err) {
+    console.error('POST /api/webhook-response error:', err);
     return res.status(500).json({ error: 'Failed to process webhook' });
   }
 });
 
 app.get('/api/webhook-response', (_req, res) => {
-  return res.json(latestPropertyData || {});
+  try {
+    return res.json(latestPayload || {});
+  } catch (err) {
+    console.error('GET /api/webhook-response error:', err);
+    return res.status(500).json({ error: 'Failed to retrieve payload' });
+  }
 });
 
-// Serve built SPA (Vite outputs to /dist)
-const dist = path.join(__dirname, 'dist');
-app.use(express.static(dist));
-app.get('*', (_req, res) => res.sendFile(path.join(dist, 'index.html')));
+app.delete('/api/webhook-response', (_req, res) => {
+  try {
+    latestPayload = {};
+    console.log('Cleared webhook payload');
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error('DELETE /api/webhook-response error:', err);
+    return res.status(500).json({ error: 'Failed to clear payload' });
+  }
+});
 
-app.listen(PORT, () => console.log(`Server listening on :${PORT}`));
+// Serve SPA
+const distPath = path.join(__dirname, 'dist');
+app.use(express.static(distPath));
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(distPath, 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on :${PORT}`);
+});
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -169,6 +169,16 @@ function App() {
     }
   };
 
+  const handleClearResults = async () => {
+    try {
+      await fetch('/api/webhook-response', { method: 'DELETE' });
+      setPropertyData(null);
+      setIsWaitingForResults(false);
+    } catch (error) {
+      console.error('Error clearing results:', error);
+    }
+  };
+
   // Poll for property data updates
   useEffect(() => {
     const checkForResults = async () => {
@@ -387,7 +397,15 @@ function App() {
 
         {propertyData && (
           <div className="mt-8 bg-white shadow-xl rounded-2xl p-8 border border-gray-100">
-            <h2 className="text-2xl font-bold text-gray-900 mb-6">Property Research Results</h2>
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-2xl font-bold text-gray-900">Property Research Results</h2>
+              <button
+                onClick={handleClearResults}
+                className="text-sm text-blue-600 hover:underline"
+              >
+                Clear results
+              </button>
+            </div>
             <div className="space-y-6">
               {formatPropertySection(
                 'Property Basics',


### PR DESCRIPTION
## Summary
- serve Vite build through Express with health and webhook endpoints
- clean build/start scripts and add render.yaml
- add frontend clear results control

## Testing
- `npm install`
- `npm run build`
- `npm run start`
- `curl -s http://localhost:3000/api/health`
- `curl -s -X POST http://localhost:3000/api/webhook-response -H "Content-Type: application/json" -d '{"ping":"ok"}'`
- `curl -s http://localhost:3000/api/webhook-response`


------
https://chatgpt.com/codex/tasks/task_e_689e9360c7f0832a942c41ba3b2ff2d5