### PR TITLE
Handle propertyData root format in parser

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,12 +61,16 @@ function App() {
       .replace(/^./, s => s.toUpperCase());
 
   const parsePropertyData = (raw: any): PropertyData => {
+    const listingData =
+      raw?.propertyData && typeof raw.propertyData === 'object'
+        ? raw.propertyData
+        : raw?.listingData && typeof raw.listingData === 'object'
+        ? raw.listingData
+        : {};
+
     return {
       propertyType: raw?.propertyType || 'Residential',
-      listingData:
-        raw?.listingData && typeof raw.listingData === 'object'
-          ? raw.listingData
-          : {},
+      listingData,
       _receivedAt: raw?._receivedAt ?? null,
     };
   };


### PR DESCRIPTION
## Summary
- Support webhook responses that place sections under `propertyData` instead of `listingData`
- Prefer `propertyData` when available, falling back to `listingData`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5f67c1b70832aaf58b64122699883