### PR TITLE
Update webhook history to deduplicate by requestId

### DIFF
--- a/server.cjs
+++ b/server.cjs
@@ -90,7 +90,7 @@ app.post('/api/webhook-response', (req, res) => {
     if (requestId) putInbox(requestId, body);
 
     const item = {
-      id: Date.now().toString(36) + Math.random().toString(36).slice(2,7),
+      id: Date.now().toString(36) + Math.random().toString(36).slice(2, 7),
       createdAt: Date.now(),
       requestId,
       parcelId:
@@ -106,7 +106,25 @@ app.post('/api/webhook-response', (req, res) => {
     };
 
     latestPropertyData = body;
-    history.unshift(item);
+
+    if (requestId) {
+      const existingIdx = history.findIndex(entry => entry.requestId === requestId);
+      if (existingIdx !== -1) {
+        const existing = history.splice(existingIdx, 1)[0];
+        const updated = {
+          ...existing,
+          ...item,
+          id: existing.id,
+          createdAt: existing.createdAt,
+        };
+        history.unshift(updated);
+      } else {
+        history.unshift(item);
+      }
+    } else {
+      history.unshift(item);
+    }
+
     if (history.length > 100) history = history.slice(0, 100);
     save();
 


### PR DESCRIPTION
## Summary
- update the webhook handler to replace existing history entries that share a requestId
- keep history ordering by moving the refreshed entry to the front and continue persisting the list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf6535d4c832a8e1b75b0b6e7d936